### PR TITLE
Add brand color and header link color

### DIFF
--- a/scss/_global-settings.scss
+++ b/scss/_global-settings.scss
@@ -1,18 +1,23 @@
+/// the theme's core brand colour
+$brand-color:           #dd4814;
+
+/// header link color
+$header-link-color:		#fff;
 
 /// Site maximum width
-$site-max-width:  984px;
+$site-max-width:  		984px;
 
 /// Resource hover
-$resource-hover:    #fafafa;
+$resource-hover:    	#fafafa;
 
 /// Resource shadow
-$resource-shadow:   #ddd;
+$resource-shadow:   	#ddd;
 
 /// Canonical aubergine
-$canonical-aubergine: #772953;
+$canonical-aubergine: 	#772953;
 
 /// Ubunut orange
-$ubuntu-orange:		#dd4814;
+$ubuntu-orange:			#dd4814;
 
 /// Box grey for buttons
-$box-solid-grey:	#efefef;
+$box-solid-grey:		#efefef;


### PR DESCRIPTION
# Done
- Added brand-color to global-settings
- Added header-link-color var to set it to white

## QA
- Run `rm -rf node_modules build`
- Run `npm install`
- Run `gulp build`
- Run `google-chrome demo/index.html`
- Check the header is orange with white text