### PR TITLE
Add breadcrumbs to demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -49,6 +49,25 @@
     </header>
     <div class="wrapper">
         <div id="main-content" class="inner-wrapper">
+            <nav role="navigation" class="nav-secondary clearfix" id="breadcrumbs">
+                <ul class="breadcrumb">
+                    <li>
+                        <a href="/server/" class="breadcrumb-link">Section&nbsp;&rsaquo;</a>
+                        <div class="breadcrumb-toggle">
+                            <a href="#" class="breadcrumb-toggle__close">Section</a>
+                            <a href="#breadcrumbs" class="breadcrumb-toggle__open">Section</a>
+                        </div>
+                    </li>
+                </ul>
+                <ul class="second-level-nav">
+                    <li class="first">
+                        <a href="#">Sub section</a>
+                    </li>
+                    <li>
+                        <a href="#">Sub section</a>
+                    </li>
+                </ul>
+            </nav>
             <div class="row" id="grid">
                 <h2>Grid</h2>
                 <div class="twelve-col box">.twelve-col</div>
@@ -384,7 +403,7 @@
                     </ul>
                 </div>
             </div>
-            <div class="row">
+            <div class="row no-border">
                 <div class="six-col">
                     <h4>.list-ticks</h4>
                     <ul class="list-ticks">

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -1,4 +1,5 @@
 
+
 // Theme variables
 @import 'global-settings';
 
@@ -15,6 +16,7 @@
 @import 'modules/arrows';
 @import 'modules/boxes';
 @import 'modules/lists';
+@import 'modules/breadcrumbs';
 
 @mixin ubuntu-vanilla-theme {
   @include vanilla;
@@ -27,5 +29,6 @@
   @include ubuntu-arrows;
   @include ubuntu-boxes;
   @include ubuntu-lists;
+  @include ubuntu-breadcrumbs;
 }
 

--- a/scss/modules/_breadcrumbs.scss
+++ b/scss/modules/_breadcrumbs.scss
@@ -1,0 +1,39 @@
+////
+/// @author       Web Team at Canonical Ltd
+/// @link         http://ubuntudesign.github.io/ubuntu-vanilla-theme/docs/#mixin-ubuntu-breadcrumbs
+/// @since        0.0.3
+////
+
+/// Default breadcrumbs styling
+/// @group Breadcrumbs
+/// @example
+/// <nav role="navigation" class="nav-secondary clearfix" id="breadcrumbs">
+///     <ul class="breadcrumb">
+///         <li>
+///             <a href="/server/" class="breadcrumb-link">Section&nbsp;&rsaquo;</a>
+///             <div class="breadcrumb-toggle">
+///                 <a href="#" class="breadcrumb-toggle__close">Section</a>
+///                 <a href="#breadcrumbs" class="breadcrumb-toggle__open">Section</a>
+///             </div>
+///         </li>
+///     </ul>
+///     <ul class="second-level-nav">
+///         <li class="first">
+///             <a href="#">Sub section</a>
+///         </li>
+///         <li>
+///             <a href="#">Sub section</a>
+///         </li>
+///     </ul>
+/// </nav>
+@mixin ubuntu-breadcrumbs {
+  .nav-secondary {
+    @media only screen and (min-width: $navigation-threshold) {
+      border-width: 0 0 1px; // removes default left and right borders
+
+      .second-level-nav  li a {
+        padding: 8px 0 0;
+      }
+    }
+  }
+}

--- a/scss/modules/_grid.scss
+++ b/scss/modules/_grid.scss
@@ -8,7 +8,7 @@
 @mixin ubuntu-grid() {
   .wrapper {
     margin: 0 auto;
-    width: $site-max-width;
+    max-width: $site-max-width;
   }
 
   .inner-wrapper {

--- a/scss/modules/_lists.scss
+++ b/scss/modules/_lists.scss
@@ -1,7 +1,6 @@
 ////
 /// @author       Web Team at Canonical Ltd
 /// @link         http://ubuntudesign.github.io/vanilla-framework/docs/#mixin-ubuntu-lists
-
 /// @since        0.0.3
 ////
 


### PR DESCRIPTION
# Done
Add breadcrumbs and tertiary nav to demo.
Add breadcrumbs sass module.
Remove an unnecessary border from the list examples.
Change width to max-width in _grid.scss as it causes horizontal scroll at anything below $site-max-width
Remove an unnecessary empty line in _lists.scss

## QA
Pull this branch and run gulp build, open /demo/index.html and note the presence of the breadcrumbs. Also note the removal of the border above .inline-list.
Check that anything below 984px ($site-max-width) does not cause horizontal scroll.

## Details
Card: https://canonical.leankit.com/Boards/View/111185042/116254678
