### PR TITLE
Update vanilla to use the new ubuntu orange colour

### DIFF
--- a/scss/_global-settings.scss
+++ b/scss/_global-settings.scss
@@ -2,7 +2,7 @@
 $asset-server: 'https://assets.ubuntu.com/v1/';
 
 /// the theme's core brand colour
-$brand-color: #dd4814;
+$brand-color: #e95420;
 
 /// header link color
 $header-link-color: #fff;
@@ -21,7 +21,7 @@ $dark-aubergine: #2c001e;
 $canonical-aubergine: #772953;
 
 /// Ubunut orange
-$ubuntu-orange: #dd4814;
+$ubuntu-orange: #e95420;
 
 /// Box grey for buttons
 $box-solid-grey: #efefef;


### PR DESCRIPTION
# Done
Update vanilla to use the new ubuntu orange colour

## QA
Make sure the new orange is #e95420

## Details
Card: https://canonical.leankit.com/Boards/View/111185042/117354121