### PR TITLE
Add inline logos to demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -449,7 +449,7 @@
                     </ul>
                 </div>
             </div>
-            <div class="row">
+            <div class="row no-border">
                 <div class="six-col">
                     <h4>.inline-list</h4>
                     <ul class="inline-list">
@@ -461,6 +461,59 @@
                         <li class="last-item">Item 6</li>
                     </ul>
                 </div>
+            </div>
+            <div class="row">
+                <h4>.inline-logos</h4>
+                <ul class="inline-logos">
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/4676d0be-lenovolowres.jpg" alt="Lenovo">
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/64f61220-emc.png" alt="EMC">
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/a9c75f9e-logo_amd.png" alt="AMD">
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/5ddba83a-logo-dell.svg" alt="Dell">
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/683950fd-logo-ibm.svg" alt="IBM">
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/4d6054f9-logo-cisco.svg" alt="Cisco">
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/a298e7ec-logo-hp.svg" alt="HP">
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/f7db330d-partner-logo-chaosprime.png" alt="ChaosPrime">
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/3630a703-partner-logo-allwinnertech.png" alt="Allwinner Technology">
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/23835286-partner-logo-rti.png" alt="Real-Time Innovations">
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/e6bc8a26-partner-logo-osrf.png" alt="OSRF">
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/d27eee64-partner-logo-banana-pro.png" alt="LeMaker">
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/8c1b05d8-partner-logo-fairwaves_t.png" alt="Fairwaves">
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/e3ca63f5-Logo_ZORAROBOTICS.png" alt="Zora Robotics">
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/25517997-partner-logo-cloudplugs.png" alt="CloudPlugs">
+                    </li>
+                    <li class="inline-logos__item">
+                        <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/153d58ce-partner-logo-solidrun.png" alt="SolidRun">
+                    </li>
+                </ul>
             </div>
             <div class="row no-border" id="tables">
                 <h2>Table</h2>


### PR DESCRIPTION
# Done
Add inline logos to demo

## QA
Run gulp build and head to demo/index.html and make sure all is well in small, medium and large.
Depends on a up to date cutting edge vanilla framework instance.

## Details
Card: https://canonical.leankit.com/Boards/View/111185042/119283633