### PR TITLE
Upgrade gulp dependancies & correct linting errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,17 @@ Then reference it from your own Sass file that is built to generate your sites C
 
 You can override any of the settings in [_global-settings.scss](scss/_global-settings.scss).
 
+## Notes
+
+You may find that after upgrading Node you get an error message like;
+
+` throw new Error('"libsass" bindings not found. Try reinstalling "node-sass"?'); `
+
+This can be resolved by installing then reinstalling node-sass;
+
+```
+  npm uninstall --save-dev gulp-sass
+  npm install --save-dev gulp-sass@2
+```
+
 Code licensed [LGPLv3](http://opensource.org/licenses/lgpl-3.0.html) by [Canonical Ltd.](http://www.canonical.com/).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@ var gulp = require('gulp'),
     notify = require('gulp-notify'),
     gutil = require('gulp-util'),
     scsslint = require('gulp-scss-lint'),
-    minifycss = require('gulp-minify-css'),
+    cleanCSS = require('gulp-clean-css');
     sassdoc = require('sassdoc'),
     util = require('util');
 
@@ -47,7 +47,7 @@ gulp.task('sass', function() {
         .pipe(autoprefixer('last 2 version', 'safari 5', 'ie 8', 'ie 9', 'opera 12.1'))
         .pipe(gulp.dest('build/css/'))
         .pipe(rename({suffix: '.min'}))
-        .pipe(minifycss())
+        .pipe(cleanCSS())
         .pipe(gulp.dest('build/css/'));
 });
 

--- a/package.json
+++ b/package.json
@@ -48,31 +48,32 @@
     "module"
   ],
   "bugs": {
-    "url" : "http://github.com/ubuntudesign/ubuntu-vanilla-theme/issues",
+    "url": "http://github.com/ubuntudesign/ubuntu-vanilla-theme/issues",
     "email": "webteam@canonical.com"
   },
-  "license" : "LGPL-3.0",
+  "license": "LGPL-3.0",
   "scripts": {
     "prepublish": "./.install_dependencies.sh",
     "clean": "rm -r build; rm -r node_modules"
   },
   "repository": {
-  "type" : "git",
-  "url" : "https://github.com/ubuntudesign/ubuntu-vanilla-theme"
+    "type": "git",
+    "url": "https://github.com/ubuntudesign/ubuntu-vanilla-theme"
   },
   "devDependencies": {
-    "gulp": "3.8.11",
+    "gulp": "3.9.1",
     "gulp-autoprefixer": "3.1.0",
     "gulp-cache": "0.2.8",
-    "gulp-minify-css": "1.0.0",
+    "gulp-clean-css": "^2.0.2",
+    "gulp-minify-css": "1.2.4",
     "gulp-notify": "2.2.0",
-    "gulp-rename": "1.2.0",
-    "gulp-sass": "1.3.3",
-    "gulp-scss-lint": "0.1.10",
-    "sassdoc": "2.1.7",
-    "gulp-util": "3.0.4"
+    "gulp-rename": "1.2.2",
+    "gulp-sass": "^2.2.0",
+    "gulp-scss-lint": "0.3.9",
+    "gulp-util": "3.0.7",
+    "sassdoc": "2.1.20"
   },
   "dependencies": {
-     "vanilla-framework": "^0.0.62"
+    "vanilla-framework": "^0.0.62"
   }
 }

--- a/scss/_global-settings.scss
+++ b/scss/_global-settings.scss
@@ -17,7 +17,7 @@ $resource-hover: #fafafa;
 $resource-shadow: #ddd;
 
 /// Canonical aubergines
-$dark-aubergine: #2c001e; 
+$dark-aubergine: #2c001e;
 $canonical-aubergine: #772953;
 
 /// Ubunut orange

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -33,4 +33,3 @@
   @include ubuntu-lists;
   @include ubuntu-breadcrumbs;
 }
-

--- a/scss/build.scss
+++ b/scss/build.scss
@@ -2,4 +2,3 @@
 
 @import 'theme';
 @include ubuntu-vanilla-theme;
-

--- a/scss/modules/_boxes.scss
+++ b/scss/modules/_boxes.scss
@@ -159,7 +159,7 @@
       background-color: $resource-hover;
     }
 
-    &:after {
+    &::after {
       box-shadow: 0 -1px 2px 0 $resource-shadow;
       content: '';
       height: 1px;
@@ -172,17 +172,17 @@
       z-index: 2;
     }
 
-    &:hover:after {
+    &:hover::after {
       right: -9px;
       top: 18px;
       width: 48px;
     }
 
-    &:before {
+    &::before {
       border-bottom: 30px solid $light-grey;
       border-radius: 0;
       border-right: 30px solid $white;
-      box-shadow: -2px 2px 2px rgba(176, 176, 176, .4);
+      box-shadow: -2px 2px 2px rgba($light-grey, .4);
       content: '';
       height: 0;
       position: absolute;
@@ -193,7 +193,7 @@
       z-index: 2;
     }
 
-    &:hover:before {
+    &:hover::before {
       border-bottom-width: 35px;
       border-right-width: 35px;
     }
@@ -226,7 +226,7 @@
     padding-right: 20px;
   }
 
-  .row-grey .resource:before {
+  .row-grey .resource::before {
     border-right-color: $light-grey;
   }
 }

--- a/scss/modules/_breadcrumbs.scss
+++ b/scss/modules/_breadcrumbs.scss
@@ -34,7 +34,7 @@
   .nav-secondary {
     @media only screen and (min-width: $navigation-threshold) {
       border-width: 0 0 1px; // removes default left and right borders
-      
+
       .breadcrumb {
         padding-top: 8px;
         padding-bottom: 7px;

--- a/scss/modules/_contextual-footer.scss
+++ b/scss/modules/_contextual-footer.scss
@@ -15,7 +15,7 @@
     padding: 0 10px;
     position: relative;
     width: 100%;
-      
+
     hr {
       background: $ubuntu-orange;
       border: 0;
@@ -24,45 +24,45 @@
       height: 14px;
       margin: 0 -10px 10px;
     }
-    
+
     div > div {
       border-bottom: 1px dotted $warm-grey;
       padding-bottom: 20px;
-      
+
       &:last-child {
         border: 0;
         padding-bottom: 0;
       }
     }
-  
+
     ul {
       margin-bottom: 5px;
     }
-    
+
     h3 {
       font-size: 1.5em;
       font-weight: normal;
       margin-bottom: .75em;
     }
   }
-  
+
   @media only screen and (min-width : 768px) {
     .context-footer {
       div > div {
         border: 0;
         padding-bottom: 0;
       }
-      
+
       hr {
         margin: 0 -30px 40px;
       }
     }
   } // end @media only screen and (max-width : 768px)
-    
+
   @media only screen and (min-width: 984px) {
     .context-footer {
       padding: 0 20px;
-      
+
       hr {
         margin: 0 -20px 40px;
       }

--- a/scss/modules/_header.scss
+++ b/scss/modules/_header.scss
@@ -8,19 +8,19 @@
 
 /// Default header styling
 @mixin ubuntu-header() {
-  
+
   @media only screen and (min-width: $navigation-threshold) {
     .banner {
       margin-bottom: 30px;
     }
   }
-  
+
   .banner .nav-primary ul {
     border: 0;
-    
+
     li {
       border-left-color: darken($brand-color, 4%);
-                  
+
       ul {
         box-shadow: 0 2px 2px -1px $warm-grey;
         border-radius: 10px;
@@ -43,29 +43,29 @@
     li a.active:visited {
       border-left: 1px solid lighten($brand-color, 4%);
       font-weight: normal;
-      
+
       &:hover {
         background: lighten($brand-color, 6%);
         box-shadow: none;
         color: $white;
       }
     }
- 
+
     ul {
       @media only screen and (min-width: $navigation-threshold) {
         display: none;
       }
-      
+
       li {
         border: 0;
       }
-      
+
       li:last-child {
         border: 0;
       }
 
     }
-    
+
     li ul li a,
     li ul li a:link,
     li ul li a:visited {
@@ -76,25 +76,25 @@
       text-align: left;
       width: 186px;
     }
-    
+
     li ul li a:link:hover,
     li ul li a:visited:hover {
       background: none;
       color: $ubuntu-orange;
     }
-        
+
     li ul li.first a:link,
     li ul li.first a:visited,
     li ul li:first-of-type a:link {
       padding: 10px 0 0 14px;
     }
-    
+
     li ul li.active a:link,
     li ul li.active a:visited {
       background: none;
     }
-    
-    li:hover ul:after {
+
+    li:hover ul::after {
       background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAICAYAAAD5nd/tAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QYODgYVPPJJpQAAAT9JREFUKM+dkD9IAnEUx7+/IkVxFaxoKYxIWhqKwJw0JAJ315Yac8+1tUFo6HCp34XRdRp11z+J4BzckqShPzdEQ5G/EhPO6V5Tcg3G0QcePHjvffjygB4oXAIApFMxyPlcWM7nwulU7NfMNQqXGABsZNcCCpcKtapBtapBCpcK2fXlAAAcy3vMlUxTdgEAO9ubybPiPjWFoE6nQ5ZlUfNDULl0RAdSPuncddL30+gnCgOAlngLaocyn4nG9fmFJXj9fhARAMDr82MuEcfk7LSuFQu8DTvovO1SuTxlAKCqPFO5Ov/6FIIsy/qzROOdrst6S1V5xunomo0LrT4yOh4JDg6BMXfvIdvGs/mExutLPZpYnAIAdmNUVuwBbI1NRODxePEf2u0WHu9u4ev3rTLTfKBQaNh1qp5piWCa9/gGBheo3r6AmYcAAAAASUVORK5CYII=') no-repeat;
       content: '';
       display: block;
@@ -105,12 +105,12 @@
       width: 200px;
       z-index: 999;
     }
-    
-    li:hover ul { 
-      display: block; 
+
+    li:hover ul {
+      display: block;
     }
   }
-  
+
   @media only screen and (min-width : $breakpoint-large) {
     .banner .logo {
       margin-left: 0;

--- a/scss/modules/_helpers.scss
+++ b/scss/modules/_helpers.scss
@@ -7,21 +7,21 @@
 /// A collect of functions to aid and enhance the users abililty
 /// @group Helpers
 @mixin ubuntu-helpers {
-  
-  .pull-left-20 { 
-    margin-left: -20px; 
+
+  .pull-left-20 {
+    margin-left: -20px;
   }
-  
-  .pull-right-20 { 
-    margin-right: -20px; 
+
+  .pull-right-20 {
+    margin-right: -20px;
   }
-  
-  .pull-left-40 { 
-    margin-left: -40px; 
+
+  .pull-left-40 {
+    margin-left: -40px;
   }
-  
-  .pull-right-40 { 
-    margin-right: -41px; 
+
+  .pull-right-40 {
+    margin-right: -41px;
   }
 
 }

--- a/scss/modules/_lists.scss
+++ b/scss/modules/_lists.scss
@@ -11,8 +11,8 @@
 ///     <li>...</li>
 ///   </ul>
 @mixin ubuntu-lists {
-  
-  /// Compact style lists with ticks 
+
+  /// Compact style lists with ticks
   .list-ticks--compact {
     @extend %list-ticks--compact;
 
@@ -21,7 +21,7 @@
     }
   }
 
-  /// Canonical style lists with ticks 
+  /// Canonical style lists with ticks
   .list-ticks--canonical {
     @extend %list-ticks;
 
@@ -30,10 +30,10 @@
     }
   }
 
-  /// Canonical compact style lists with ticks 
+  /// Canonical compact style lists with ticks
   .list-ticks--canonical-compact {
     @extend %list-ticks--compact;
-  
+
     li {
       background-image: svg-tick($canonical-aubergine);
     }

--- a/scss/modules/_rows.scss
+++ b/scss/modules/_rows.scss
@@ -16,21 +16,21 @@
     background-color: $dark-aubergine;
     background-image: url('#{$asset-server}62d597f6-background-grid.png');
     color: $white;
-  
+
     .resource {
       box-shadow: none;
       color: $text-color;
       padding-right: 20px;
     }
-  
-    .resource:before {
+
+    .resource::before {
       border-bottom-width: 29px;
       border-right-color: $dark-aubergine;
       right: -2px;
       top: -1px;
     }
-  
-    .resource:hover:before {
+
+    .resource:hover::before {
       border-bottom-width: 34px;
     }
   }


### PR DESCRIPTION
## Done

- Upgraded gulp dependancies and replaced deprecated modules. 
- Fixed reported scss lint errors
- Added note in rEADME about gulp-sass gotcha after upgrading node

## QA

Pull down code and run `npm i` - all modules should install without error. Then run `gulp build` without error.

Fixes: #137 


