### PR TITLE
Bump Vanilla Framework Dependancy to 0.0.63

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,6 @@
     "sassdoc": "2.1.20"
   },
   "dependencies": {
-    "vanilla-framework": "^0.0.62"
+    "vanilla-framework": "^0.0.63"
   }
 }


### PR DESCRIPTION
## Done
Bumped the VF dependancy so that this theme can inherit full width styling.

## QA
Pull down, delete node_modules, make sure `npm i` runs without error.