### PR TITLE
Correct `ubuntu_orange` lint error

### DIFF
--- a/scss/modules/_buttons.scss
+++ b/scss/modules/_buttons.scss
@@ -28,7 +28,7 @@
     color: $white;
 
     &:hover {
-      background: darken($ubuntu_orange, 6.2%);
+      background: darken($ubuntu-orange, 6.2%);
       text-decoration: none;
     }
   }


### PR DESCRIPTION
## Done

Update single instance of `ubuntu_orange` to match other `ubuntu-orange`
uses. This also fixes a lint error.

## QA

Run `gulp test` without errors.