### PR TITLE
Fix issue #103

### DIFF
--- a/scss/modules/_grid.scss
+++ b/scss/modules/_grid.scss
@@ -17,6 +17,9 @@
     box-shadow: 0 0 3px $mid-grey;
     margin: 10px 0 30px;
     padding-bottom: 20px;
+    
+    @media only screen and (max-width: $breakpoint-large + 1) {
+      margin: 0;
+    }
   }
-
 }

--- a/scss/modules/_header.scss
+++ b/scss/modules/_header.scss
@@ -9,7 +9,7 @@
 /// Default header styling
 @mixin ubuntu-header() {
 
-  @media only screen and (min-width: $navigation-threshold) {
+  @media only screen and (min-width: $breakpoint-large + 1) {
     .banner {
       margin-bottom: 30px;
     }
@@ -111,7 +111,7 @@
     }
   }
 
-  @media only screen and (min-width : $breakpoint-large) {
+  @media only screen and (min-width : $breakpoint-large + 1) {
     .banner .logo {
       margin-left: 0;
     }


### PR DESCRIPTION
Some pages have space below main nav and above content [sm]

# Done
Remove inner-wrapper and header margins below breakpoint large

## QA
Run ‘gulp build’ the have a look at the demo at various breakpoints an
make sure there’s no gap below the main nav below breakpoint-large (984)

## Details
Card: https://trello.com/c/skfpDoWt
Issue: https://github.com/ubuntudesign/www.ubuntu.com/issues/103