### PR TITLE
Fix issue 55

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -32,7 +32,7 @@
                 <ul>
                     <li><a href="#grid">Grid</a>
                         <ul class="second-level-nav">
-                            <li><a href="#nested-grid">Nested grid</a></li>
+                            <li><a class="active" href="#nested-grid">Nested grid</a></li>
                         </ul>
                     </li>
                     <li><a href="#forms">Forms</a>

--- a/scss/modules/_header.scss
+++ b/scss/modules/_header.scss
@@ -77,27 +77,25 @@
       width: 186px;
     }
 
-    li ul li a:link:hover,
-    li ul li a:visited:hover {
-      background: none;
-      color: $ubuntu-orange;
+    .second-level-nav li a {
+      &:link:hover,
+      &:visited:hover {
+        background: none;
+        color: $ubuntu-orange;
+      }
     }
 
-    li ul li.first a:link,
-    li ul li.first a:visited,
-    li ul li:first-of-type a:link {
-      padding: 10px 0 0 14px;
+    .second-level-nav .active {
+      &:link,
+      &:visited,
+      &:link:hover,
+      &:visited:hover {
+        background: none;
+        border: 0;
+        color: $cool-grey;
+      }
     }
-
-    li ul .active:link,
-    li ul .active:visited,
-    li ul .active:link:hover,
-    li ul .active:visited:hover {
-      background: none;
-      border: 0;
-      color: $cool-grey;
-    }
-        
+      
     li:hover ul::after {
       background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAICAYAAAD5nd/tAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QYODgYVPPJJpQAAAT9JREFUKM+dkD9IAnEUx7+/IkVxFaxoKYxIWhqKwJw0JAJ315Yac8+1tUFo6HCp34XRdRp11z+J4BzckqShPzdEQ5G/EhPO6V5Tcg3G0QcePHjvffjygB4oXAIApFMxyPlcWM7nwulU7NfMNQqXGABsZNcCCpcKtapBtapBCpcK2fXlAAAcy3vMlUxTdgEAO9ubybPiPjWFoE6nQ5ZlUfNDULl0RAdSPuncddL30+gnCgOAlngLaocyn4nG9fmFJXj9fhARAMDr82MuEcfk7LSuFQu8DTvovO1SuTxlAKCqPFO5Ov/6FIIsy/qzROOdrst6S1V5xunomo0LrT4yOh4JDg6BMXfvIdvGs/mExutLPZpYnAIAdmNUVuwBbI1NRODxePEf2u0WHu9u4ev3rTLTfKBQaNh1qp5piWCa9/gGBheo3r6AmYcAAAAASUVORK5CYII=') no-repeat;
       content: '';

--- a/scss/modules/_header.scss
+++ b/scss/modules/_header.scss
@@ -89,11 +89,15 @@
       padding: 10px 0 0 14px;
     }
 
-    li ul li.active a:link,
-    li ul li.active a:visited {
+    li ul .active:link,
+    li ul .active:visited,
+    li ul .active:link:hover,
+    li ul .active:visited:hover {
       background: none;
+      border: 0;
+      color: $cool-grey;
     }
-
+        
     li:hover ul::after {
       background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAICAYAAAD5nd/tAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QYODgYVPPJJpQAAAT9JREFUKM+dkD9IAnEUx7+/IkVxFaxoKYxIWhqKwJw0JAJ315Yac8+1tUFo6HCp34XRdRp11z+J4BzckqShPzdEQ5G/EhPO6V5Tcg3G0QcePHjvffjygB4oXAIApFMxyPlcWM7nwulU7NfMNQqXGABsZNcCCpcKtapBtapBCpcK2fXlAAAcy3vMlUxTdgEAO9ubybPiPjWFoE6nQ5ZlUfNDULl0RAdSPuncddL30+gnCgOAlngLaocyn4nG9fmFJXj9fhARAMDr82MuEcfk7LSuFQu8DTvovO1SuTxlAKCqPFO5Ov/6FIIsy/qzROOdrst6S1V5xunomo0LrT4yOh4JDg6BMXfvIdvGs/mExutLPZpYnAIAdmNUVuwBbI1NRODxePEf2u0WHu9u4ev3rTLTfKBQaNh1qp5piWCa9/gGBheo3r6AmYcAAAAASUVORK5CYII=') no-repeat;
       content: '';


### PR DESCRIPTION
Fix issue 55 - Main nav dropdown shouldn't highlight current page

# Done
Remove background color from ctive item in dropdown

## QA
On line 34 of the demo change the following:

`<li><a href="#nested-grid">Nested grid</a></li>`

to:

`<li><a class="active" href="#nested-grid">Nested grid</a></li>`

then open the demo and note that the active item in the dropdown, in this instance Nested grid has a background color, IT SHOULDN'T.

Run 'gulp build' and it will make the orange go away.

## Details
Card: https://trello.com/c/jkrCISO8
Issue: https://github.com/ubuntudesign/ubuntu-vanilla-theme/issues/55