### PR TITLE
add body background for small viewport

### DIFF
--- a/scss/modules/_base.scss
+++ b/scss/modules/_base.scss
@@ -7,9 +7,14 @@
 /// Base classes
 /// @group Utils
 @mixin ubuntu-base {
-  @media only screen and (min-width : $breakpoint-medium) {
-    body {
-      background: url('#{$asset-path}img/backgrounds/image-background-paper.png') repeat-y center top $light-grey;
+  body {
+    background-color: $light-grey;
+    background-image: url('#{$asset-path}img/backgrounds/image-background-paper.png?w=$breakpoint-medium');
+    background-position: center top;
+    background-repeat: repeat-y;
+
+    @media only screen and (min-width : $breakpoint-medium) {
+      background-image: url('#{$asset-path}img/backgrounds/image-background-paper.png');
     }
   }
 }


### PR DESCRIPTION
### Done
Added a background image for small viewports

### QA
Until we redesign the demo to be full-width, this image isn't very visible.
Scroll to the footer and see that the image is in the background.