### PR TITLE
Fix font size issue

### DIFF
--- a/scss/modules/_contextual-footer.scss
+++ b/scss/modules/_contextual-footer.scss
@@ -11,7 +11,7 @@
     box-sizing: border-box;
     clear: both;
     display: block;
-    font-size: .75em;
+    font-size: .875em;
     padding: 0 10px;
     position: relative;
     width: 100%;


### PR DESCRIPTION
## Done

Fix contextual footer font size issue 

## QA

Run gulp build then have a look at the demo and the paragraph for size should match live (14px) it’s currently 12px, this is wrong.

## Details

Issue: https://github.com/ubuntudesign/www.ubuntu.com/issues/130