### PR TITLE
Add blockquotes right/left padding

### DIFF
--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -19,6 +19,7 @@
 @import 'modules/lists';
 @import 'modules/breadcrumbs';
 @import 'modules/search';
+@import 'modules/blockquotes';
 
 @mixin ubuntu-vanilla-theme {
   @include vanilla;
@@ -34,4 +35,5 @@
   @include ubuntu-lists;
   @include ubuntu-breadcrumbs;
   @include ubuntu-search;
+  @include ubuntu-blockquotes;
 }

--- a/scss/modules/_blockquotes.scss
+++ b/scss/modules/_blockquotes.scss
@@ -1,0 +1,18 @@
+////
+/// @author       Web Team at Canonical Ltd
+/// @link         https://github.com/ubuntudesign/ubuntu-vanilla-theme
+/// @since        0.0.025
+////
+
+/// Default blockquote styling
+/// @group Blockquotes
+/// @example
+/// <blockquote>
+///   ...
+/// </blockquote>
+@mixin ubuntu-blockquotes {
+
+  blockquote {
+    padding: inherit 1em;
+  }
+}


### PR DESCRIPTION
## Done
Add left/right padding to blockquotes so that pseudo :before/:after quotations adhere to grid.

## QA
Pull down and check that blockquote quotations do not leak outside the grid across breakpoints.

## Fixes
https://github.com/ubuntudesign/www.ubuntu.com/issues/181