### PR TITLE
fixing small screen contextual footer

### DIFF
--- a/scss/modules/_contextual-footer.scss
+++ b/scss/modules/_contextual-footer.scss
@@ -22,7 +22,7 @@
       box-shadow: inset 0 2px 2px -2px $warm-grey;
       clear: both;
       height: 14px;
-      margin: 0 -10px 10px;
+      margin: 0 -10px 20px;
     }
 
     div > div {

--- a/scss/modules/_grid.scss
+++ b/scss/modules/_grid.scss
@@ -15,9 +15,13 @@
     background: $white;
     border-radius: 4px;
     box-shadow: 0 0 3px $mid-grey;
-    margin: 10px 0 30px;
-    padding-bottom: 20px;
-    
+    margin: 10px 0 0;
+    padding-bottom: 0;
+
+    @media only screen and (max-width: $breakpoint-medium) {
+      margin: 10px 0 30px;
+      padding-bottom: 20px;
+    }
     @media only screen and (max-width: $breakpoint-large + 1) {
       margin: 0;
     }


### PR DESCRIPTION
Details
===

* Fixes [382](https://github.com/ubuntudesign/www.ubuntu.com/issues/382) - Contextual footer: needs more top padding and less bottom padding (site-wide)
* card: https://trello.com/c/RKiBozQS

done
---

* created a media query for medium
* added the existing small margin and padding-bottom to it
* downsized the small margin and padding-bottom

qa
---

1. gulp build UVT
2. look at the demo (/demo/index.html) on a small screen 
3. see that there is less whitespace between the last contextual footer and the footer

![image](https://cloud.githubusercontent.com/assets/441217/14582161/874d3d30-03f5-11e6-8316-a7640523f80e.png)
![image](https://cloud.githubusercontent.com/assets/441217/14582146/1732bb10-03f5-11e6-96cb-fe4f4057283d.png)
