### PR TITLE
Use sass import paths to include vanilla framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,30 @@ Install the Node package into your project:
 npm install ubuntu-vanilla-theme  # Installs the theme with the framework within
 ```
 
+Configure Sass import paths.
+
+Composer:
+
+```
+add_import_path "node_modules"
+```
+
+Gulp:
+
+```javascript
+gulp.task('sass', function() {
+    return gulp.src('[your-sass-directory]/**/*.scss')
+      .pipe(sass({
+        includePaths: ['node_modules']
+      }))
+});
+```
+
 Then reference it from your own Sass file that is built to generate your sites CSS:
 
 ``` sass
 // Import the theme
-@import "../../node_modules/ubuntu-vanilla-theme/scss/theme";
+@import "ubuntu-vanilla-theme/scss/theme";
 // Run the theme
 @include ubuntu-vanilla-theme;
 ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,8 @@ var gulp = require('gulp'),
     sassdoc = require('sassdoc'),
     util = require('util');
 
+var sassImportPaths = ['../', 'node_modules'];
+
 /* Helper functions */
 function throwSassError(sassError) {
     throw new gutil.PluginError({
@@ -42,7 +44,8 @@ gulp.task('sass', function() {
     return gulp.src('scss/**/*.scss')
         .pipe(sass({
             style: 'expanded',
-            onError: throwSassError
+            onError: throwSassError,
+            includePaths: ['scss'].concat(sassImportPaths)
         }))
         .pipe(autoprefixer('last 2 version', 'safari 5', 'ie 8', 'ie 9', 'opera 12.1'))
         .pipe(gulp.dest('build/css/'))
@@ -60,7 +63,7 @@ gulp.task('build', ['sasslint', 'sass', 'docs']);
 
 gulp.task('sass-lite', function() {
     return gulp.src('scss/**/*.scss')
-        .pipe(sass({ style: 'expanded', errLogToConsole: true }))
+        .pipe(sass({ style: 'expanded', errLogToConsole: true, includePaths: ['scss'].concat(sassImportPaths) }))
         .pipe(autoprefixer('last 2 version', 'safari 5', 'ie 8', 'ie 9', 'opera 12.1'))
         .pipe(gulp.dest('build/css/'));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ var gulp = require('gulp'),
     sassdoc = require('sassdoc'),
     util = require('util');
 
+// ../ is here just for reference.
 var sassImportPaths = ['../', 'node_modules'];
 
 /* Helper functions */

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -4,7 +4,7 @@
 @import 'global-settings';
 
 // import required files
-@import '../node_modules/vanilla-framework/scss/vanilla';
+@import 'vanilla-framework/scss/vanilla';
 
 /// ubuntu element styles
 @import 'modules/base';


### PR DESCRIPTION
Fixes #26

This PR adds import paths for both npm2 and npm3 locations and avoids plain paths in `@import` directives.

Advantages:
- No need to check whether npm version is 2 or 3
- If one of the import paths does not exist, it is just skipped
- No plain paths in `@import` directives

Disadvantages:
You must either use gulp or configure another compiler in the same way, but it's just a matter of documenting it.

### Note
It has been tested with npm2, should be tested with npm3. Other packages need to include the same import paths.